### PR TITLE
Resolve Gem::Specification#has_rdoc DEPRECATION WARNING

### DIFF
--- a/resque-lock.gemspec
+++ b/resque-lock.gemspec
@@ -1,12 +1,11 @@
 Gem::Specification.new do |s|
   s.name              = "resque-lock"
-  s.version           = "1.1.0"
+  s.version           = "1.1.1"
   s.date              = Time.now.strftime('%Y-%m-%d')
   s.summary           = "A Resque plugin for ensuring only one instance of your job is queued at a time."
   s.homepage          = "http://github.com/defunkt/resque-lock"
   s.email             = "chris@ozmm.org"
   s.authors           = [ "Chris Wanstrath", "Ray Krueger" ]
-  s.has_rdoc          = false
 
   s.files             = %w( README.md Rakefile LICENSE )
   s.files            += Dir.glob("lib/**/*")


### PR DESCRIPTION
This DEPRECATION WARNING shows up while installing this gem.

```
Fetching git@github.com:hoverinc/resque-lock.git
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /usr/local/bundle/bundler/gems/resque-lock-a600099ecaf2/resque-lock.gemspec:9.
```

It's because our private repo/gem is fork of @defunkt's super duper old untouched in a million years gem. 